### PR TITLE
docs: update security email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,9 @@
 Versions that are supported currently:
 
 | Version    | Supported          |
-|------------| ------------------ |
+| ---------- | ------------------ |
 | unreleased | :white_check_mark: |
-
 
 ## Reporting a Vulnerability
 
-When reporting a vulnerability please make sure to let us know immediately on our issues tab or make sure to get in contact with us either on the discord or though our [email](mailto:support@waldo.vision)
+When reporting a vulnerability please make sure to let us know immediately on our issues tab or make sure to get in contact with us either on the discord or though our [email](mailto:security@waldo.vision)


### PR DESCRIPTION
Should be a dedicated security email since potentially the support email would be less guarded then a security dedicated one. (Also we are gonna need to set up an email up.)